### PR TITLE
Add scraper for blood stocks levels from redcross.sg

### DIFF
--- a/netlify/functions/redcross-bloodstocks.js
+++ b/netlify/functions/redcross-bloodstocks.js
@@ -1,0 +1,56 @@
+const got = require('got')
+const cheerio = require('cheerio')
+const REDCROSS_HOST = "https://www.redcross.sg"
+const BLOOD_BANK_LVL = "blood_bank_level"
+const POS_NEG = [{"class_": "positives", "name": "+"}, {"class_": "negatives", "name": "-"}]
+const BLOOD_GROUP_PREFIX = "blood_group"
+const BLOOD_GROUPS = [
+  {"class_": "a_group", "name": "A"},
+  {"class_": "b_group", "name": "B"},
+  {"class_": "o_group", "name": "O"},
+  {"class_": "ab_group", "name": "AB"},
+]
+
+
+async function extractBloodStocks(url) {
+  const response = await got(url);
+  const $ = cheerio.load(response.body)
+
+  let state = {}
+
+  for (const pos_neg of POS_NEG) {
+    // Get the entire positive or negative blood type row
+    const classname = `.${BLOOD_BANK_LVL}.${pos_neg["class_"]}`
+    const pos_or_negs = $(classname)
+    for (const group of BLOOD_GROUPS) {
+      // Get data for individual blood types
+      const classname = `.${BLOOD_GROUP_PREFIX}.${group["class_"]}`
+      const bloodgroup_html = pos_or_negs.children(classname);
+      const info_text = bloodgroup_html.find(".info_text")
+      const bloodtype = info_text.find(".status_text:nth-child(1)").text().split(' ')[0]
+      const status = info_text.find(".status_text:nth-child(2)").text()
+      const fill_level = bloodgroup_html.find(".fill_humam").css('height')
+      // console.log(bloodtype);
+      // console.log(status);
+      // console.log(fill_level)
+      state[bloodtype] = {"status": status, "fill_level": fill_level}
+    }
+  }
+  return state
+  
+}
+
+async function runExtracter() {
+  const result = await extractBloodStocks(`${REDCROSS_HOST}`)
+  return { statusCode: 200, body: JSON.stringify(result, null, 2) }
+}
+
+
+exports.handler = async function () {
+  return await runExtracter();
+}
+
+// For testing
+// runExtracter().then((data) => {
+//     console.log(data)
+// })


### PR DESCRIPTION
This scraper adds the blood stocks levels from the Red Cross website (redcross.sg)

It parses these html elements to get the "fill level" (which appears to be an accurate value of the blood level) for each blood type, and its "status" (Healthy/Moderate/Low/Critical)
![image](https://user-images.githubusercontent.com/5507069/121855628-28175080-cd26-11eb-86b8-481779a24e95.png)


An example of the json format from a scrape on June 14th 2021 3:37 PM is:
```js
{
  'A+': { status: 'Healthy', fill_level: '100%' },
  'B+': { status: 'Healthy', fill_level: '100%' },
  'O+': { status: 'Healthy', fill_level: '96%' },
  'AB+': { status: 'Healthy', fill_level: '100%' },
  'A-': { status: 'Moderate', fill_level: '51%' },
  'B-': { status: 'Low', fill_level: '43%' },
  'O-': { status: 'Low', fill_level: '44%' },
  'AB-': { status: 'Critical', fill_level: '30%' }
}
```